### PR TITLE
Add unit tests for createDomainMap

### DIFF
--- a/src/components/common.test.ts
+++ b/src/components/common.test.ts
@@ -1,0 +1,38 @@
+import { createDomainMap } from './common';
+
+describe('createDomainMap', () => {
+  it('returns empty map and undefined firstDomain when input is null', () => {
+    const result = createDomainMap(null);
+    expect(result).toEqual({ domainMap: {}, firstDomain: undefined });
+  });
+
+  it('maps domains correctly and identifies first domain', () => {
+    const domains = [
+      { id: 'example.com' },
+      { id: 'foo.com' },
+      { id: 'bar.com' }
+    ];
+    const result = createDomainMap(domains);
+    expect(result.domainMap).toEqual({
+      'example.com': 'example.com',
+      'foo.com': 'foo.com',
+      'bar.com': 'bar.com'
+    });
+    expect(result.firstDomain).toBe('example.com');
+  });
+
+  it('ignores entries without id and still finds first valid domain', () => {
+    const domains = [
+      {},
+      { id: 'valid.com' },
+      { notId: 'skip.com' },
+      { id: 'another.com' }
+    ] as any;
+    const result = createDomainMap(domains);
+    expect(result.domainMap).toEqual({
+      'valid.com': 'valid.com',
+      'another.com': 'another.com'
+    });
+    expect(result.firstDomain).toBe('valid.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for `createDomainMap` ensuring correct domain map creation and first-domain detection

## Testing
- `npm test -- --coverage --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68783d8bd7e48329b013dc57fd76dae5