### PR TITLE
Fix DeleteDomainDialog state initialization

### DIFF
--- a/src/components/dialogs/custom/DeleteDomainDialog.tsx
+++ b/src/components/dialogs/custom/DeleteDomainDialog.tsx
@@ -13,9 +13,11 @@ export const DeleteDomainDialog: FunctionComponent<{
     const [deleteDomain] = useDeleteDomainMutation();
     const { domainMap, firstDomain } = createDomainMap(domains);
 
-    if (firstDomain && !value) {
-        setValue(firstDomain);
-    }
+    React.useEffect(() => {
+        if (firstDomain && !value) {
+            setValue(firstDomain);
+        }
+    }, [firstDomain]);
 
     return (
         <SelectDialog


### PR DESCRIPTION
## Summary
- ensure DeleteDomainDialog sets default domain via `useEffect`
- keep passing `initialValue` to SelectDialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878453f65988329bf9d983d72e330b6