### PR TITLE
Initialize UpdateDomainDialog with useEffect

### DIFF
--- a/src/components/dialogs/custom/UpdateDomainDialog.tsx
+++ b/src/components/dialogs/custom/UpdateDomainDialog.tsx
@@ -14,10 +14,12 @@ export const UpdateDomainDialog: FunctionComponent<{
     const { domainMap, firstDomain } = createDomainMap(domains);
     const [updateDomain] = useUpdateDomainMutation();
 
-    if (firstDomain && !value) {
-        setValue(firstDomain);
-        setDialogText(firstDomain);
-    }
+    React.useEffect(() => {
+        if (firstDomain && !value) {
+            setValue(firstDomain);
+            setDialogText(firstDomain);
+        }
+    }, [firstDomain]);
 
     return (
         <SelectTextFieldDialog


### PR DESCRIPTION
## Summary
- initialize `UpdateDomainDialog` state with `useEffect`
- keep select and text inputs bound to state

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878477bd56083299e5afcc78c5a0a3d