### PR TITLE
Fix Cypress config for component tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   component: {
     devServer: {
-      framework: 'create-react-app',
+      framework: 'react',
       bundler: 'webpack',
     },
     setupNodeEvents(on, config) {

--- a/cypress/component/login.cy.tsx
+++ b/cypress/component/login.cy.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'cypress/react18';
+import { mount } from 'cypress/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/client';
 import { Login } from '../../src/components/pages/Login';

--- a/cypress/component/sideDrawer.cy.tsx
+++ b/cypress/component/sideDrawer.cy.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'cypress/react18';
+import { mount } from 'cypress/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/client';
 import { SideDrawer } from '../../src/components/nav/SideDrawer';

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Cypress Component Testing</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,9 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+const reactScriptsConfig = require('react-scripts/config/webpack.config');
+const config = reactScriptsConfig(process.env.NODE_ENV);
+const path = require('path');
+const tsRule = config.module.rules[1].oneOf.find(r => r.test && r.test.toString().includes('ts'));
+if (tsRule && tsRule.include) {
+  tsRule.include = [tsRule.include, path.resolve(__dirname, 'cypress')];
+}
+module.exports = config;


### PR DESCRIPTION
## Summary
- fix Cypress configuration to use React dev server
- use Create React App webpack configuration
- allow compiling Cypress TypeScript specs
- update component spec imports
- add HTML mount point for Cypress component tests

## Testing
- `xvfb-run -a npx cypress run --component` *(fails: some tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6878b545aafc83298693be998e488170