### PR TITLE
Handle network errors gracefully

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,13 +10,13 @@ This document outlines the planned features for the Blenheim client and lists th
 - **GraphQL Integration** – All data is fetched and mutated through Apollo Client with a type-safe codegen setup.
 - **Docker & Deployment** – A `Dockerfile` and Kubernetes deployment manifest are provided for containerized deployments.
 - **Testing Infrastructure** – Jest unit tests and Cypress component tests are configured with coverage reporting.
+- **Error Handling** – Friendlier error messages appear for network and server failures.
 
 ## Upcoming Roadmap
 
 ### Short Term
 
 - **UI Polish** – Improve page layouts and navigation for smaller screens.
-- **Error Handling** – Display friendlier error messages for network and server failures.
 - **Continuous Integration** – Add automated test runs and lints in CI.
 
 ### Medium Term

--- a/src/components/nav/Generate.tsx
+++ b/src/components/nav/Generate.tsx
@@ -3,6 +3,7 @@ import { QUERY } from '../queries/DnsQuery';
 import { SingleButtonDialog } from '../dialogs/generic/SingleButtonDialog';
 import { useLazyQuery } from '@apollo/client';
 import { Box, Button, Typography } from '@mui/material';
+import { formatErrorMessage } from '../../utils/errorMessage';
 import ErrorIcon from '@mui/icons-material/Error';
 import InfoIcon from '@mui/icons-material/Info';
 import { DnsQuery, DnsQueryVariables } from '../../gql/graphql';
@@ -32,7 +33,7 @@ export const Generate: FunctionComponent = () => {
     useEffect(() => {
         if (queryError) {
             setError(true);
-            setResult(queryError.message || '');
+            setResult(formatErrorMessage(queryError));
         }
     }, [queryError]);
 

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -4,6 +4,7 @@ import { HOME } from '../../App';
 import { useLazyQuery } from '@apollo/client';
 import { LOGIN_QUERY } from '../queries/LoginQuery';
 import { Avatar, Box, Button, Container, CssBaseline, TextField, Typography } from '@mui/material';
+import { formatErrorMessage } from '../../utils/errorMessage';
 import { useNavigate } from 'react-router-dom';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { LoginQuery, LoginQueryVariables } from '../../gql/graphql';
@@ -123,7 +124,7 @@ export const Login: React.FC = (): JSX.Element => {
                     </Button>
                 </form>
                 {loading && (<span>Loading...</span>)}
-                {error && (<span>Error! {error.message}</span>)}
+                {error && (<span>Error! {formatErrorMessage(error)}</span>)}
             </div>
         </Container>
     );

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,0 +1,11 @@
+import { ApolloError } from '@apollo/client';
+
+export function formatErrorMessage(error: ApolloError): string {
+    if (error.networkError) {
+        return 'Network error: Please check your connection and try again.';
+    }
+    if (error.graphQLErrors && error.graphQLErrors.length > 0) {
+        return error.graphQLErrors[0].message;
+    }
+    return error.message || 'An unexpected error occurred.';
+}


### PR DESCRIPTION
## Summary
- show friendlier error messages in the Login page and Generate dialog
- list error handling as a completed feature in the roadmap

## Testing
- `npm test -- --coverage --watchAll=false`
- `npx cypress run --component` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_687932a113f883299a614678a378affc