### PR TITLE
Ensure cypress can run in Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Cypress Tests
 -------------
 
 1. Install dependencies with `npm install`.
-2. Run component tests with `npx cypress run --component`.
-3. Coverage reports are generated in `coverage/lcov-report`.
+2. Ensure the `xvfb` package is installed (`sudo apt-get install -y xvfb`).
+3. Run component tests with `npm run test:cypress`.
+4. Coverage reports are generated in `coverage/lcov-report`.
 
 Unit Tests
 ----------

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:cypress": "cypress run --component",
     "eject": "react-scripts eject",
     "codegen": "graphql-codegen --config codegen.ts"
   },


### PR DESCRIPTION
## Summary
- add `test:cypress` script for running component tests
- document xvfb requirement and cypress test command

## Testing
- `npm run test:cypress` *(fails: avigates to domains...)*

------
https://chatgpt.com/codex/tasks/task_e_687a0892c1e083298fcd414e0ba16746